### PR TITLE
FIX: relative imports for python3

### DIFF
--- a/python/__init__.py
+++ b/python/__init__.py
@@ -1,15 +1,13 @@
-from _blitzl1 import LassoProblem
-from _blitzl1 import LogRegProblem
+from ._blitzl1 import LassoProblem
+from ._blitzl1 import LogRegProblem
 
-from _blitzl1 import load_solution
+from ._blitzl1 import load_solution
 
-from _blitzl1 import set_tolerance
-from _blitzl1 import get_tolerance
-from _blitzl1 import set_max_time
-from _blitzl1 import get_max_time
-from _blitzl1 import set_use_intercept
-from _blitzl1 import get_use_intercept
-from _blitzl1 import set_verbose
-from _blitzl1 import get_verbose
-
-
+from ._blitzl1 import set_tolerance
+from ._blitzl1 import get_tolerance
+from ._blitzl1 import set_max_time
+from ._blitzl1 import get_max_time
+from ._blitzl1 import set_use_intercept
+from ._blitzl1 import get_use_intercept
+from ._blitzl1 import set_verbose
+from ._blitzl1 import get_verbose


### PR DESCRIPTION
Hi,

Currently the package is not usable under python 3, because of absolute imports in its __init__py (see [this SO question](https://stackoverflow.com/questions/12172791/changes-in-import-statement-python3))
This PR addresses this issue by using `from ._blitzl1 import foo`