### PR TITLE
FIX python check array ctype

### DIFF
--- a/python/_blitzl1.py
+++ b/python/_blitzl1.py
@@ -79,7 +79,7 @@ def get_verbose():
 
 def data_as(obj, ctypes_type):
   if obj.dtype != ctypes_type._type_:
-    obj = obj.astype(ctypes_type)
+    obj = obj.astype(ctypes_type._type_)
   return (obj, obj.ctypes.data_as(ctypes_type))
 
 

--- a/python/_blitzl1.py
+++ b/python/_blitzl1.py
@@ -78,7 +78,7 @@ def get_verbose():
 
 
 def data_as(obj, ctypes_type):
-  if obj.dtype != ctypes_type:
+  if obj.dtype != ctypes_type._type_:
     obj = obj.astype(ctypes_type)
   return (obj, obj.ctypes.data_as(ctypes_type))
 


### PR DESCRIPTION
When running on python3.6, I get the following error:

```python-traceback
Traceback (most recent call last):
  File "$HOME/benchOpt/benchopt/base.py", line 285, in run_benchmark
    solver_parameters, max_iter, n_rep=n_rep))
  File "$PYTHON_SITE_PACKAGES/joblib/memory.py", line 568, in __call__
    return self._cached_call(args, kwargs)[0]
  File "$PYTHON_SITE_PACKAGES/joblib/memory.py", line 534, in _cached_call
    out, metadata = self.call(*args, **kwargs)
  File "$PYTHON_SITE_PACKAGES/joblib/memory.py", line 734, in call
    output = self.func(*args, **kwargs)
  File "$HOME/benchOpt/benchopt/base.py", line 213, in run_one_solver
    solver.set_loss(loss_parameters)
  File "$HOME/benchOpt/benchmarks/lasso/solvers/blitz.py", line 24, in set_loss
    self.problem = blitzl1.LassoProblem(self.X, self.y)
  File "$PYTHON_SITE_PACKAGES/blitzl1/_blitzl1.py", line 89, in __init__
    self._load_dataset(A, b)
  File "$PYTHON_SITE_PACKAGES/blitzl1/_blitzl1.py", line 95, in _load_dataset
    (self._b, labels_arg) = data_as(b, _value_t_p)
  File "$PYTHON_SITE_PACKAGES/blitzl1/_blitzl1.py", line 81, in data_as
    if obj.dtype != ctypes_type:
  File "$PYTHON_SITE_PACKAGES/numpy/core/_dtype_ctypes.py", line 104, in dtype_from_ctypes_type
    raise TypeError("ctypes pointers have no dtype equivalent")
TypeError: ctypes pointers have no dtype equivalent
```


This seems to be an issue with the ctype check with dtype in the python API.
I found this hot fix, not sure this is working for old python version but it seems to do the trick for python3.6.