### PR TITLE
FIX replace random_shuffle by shuffle

### DIFF
--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <algorithm>
 #include <limits>
+#include <random>
 
 using std::cout;
 using std::endl;
@@ -156,12 +157,15 @@ namespace BlitzL1
       prox_newton_epsilon = PROX_NEWTON_EPSILON_RATIO * prox_newton_grad_diff;
     }
 
+    std::random_device rd;
+    std::mt19937 g(rd());
+
     // Approximately solve for newton direction:
     for (int cd_itr = 0; cd_itr < max_cd_itr; ++cd_itr)
     {
 
       // Shuffle indices:
-      random_shuffle(rand_permutation.begin(), rand_permutation.end());
+      shuffle(rand_permutation.begin(), rand_permutation.end(), g);
       for (size_t rp_ind = 0; rp_ind < working_set_size; ++rp_ind)
       {
         size_t new_index = rand_permutation[rp_ind];


### PR DESCRIPTION
for c++17
currently blitz can't be installed on macos github CI runners:

```
----------------------------- Captured stderr call -----------------------------
  Running command git clone --filter=blob:none --quiet https://github.com/tbjohns/blitzl1.git /private/var/folders/qv/pdh5wsgn0lq3dp77zj602b5c0000gn/T/pip-req-build-a1gbjzvu
  error: subprocess-exited-with-error
  
  × python setup.py bdist_wheel did not run successfully.
  │ exit code: 1
  ╰─> [5 lines of output]
      src/solver.cpp:164:7: error: use of undeclared identifier 'random_shuffle'
            random_shuffle(rand_permutation.begin(), rand_permutation.end());
            ^
      1 error generated.
      error: command '/Users/runner/miniconda3/envs/bench_test_env/bin/x86_64-apple-darwin13.4.0-clang' failed with exit code 1
      [end of output]
 ```